### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -13,7 +13,7 @@ Usage
    minor will be bumped to indicate backwards-incompatible changes.
 
       [dependencies]
-      exif = "0.3"
+      kamadak-exif = "0.3"
 
    Add the following to your crate root.
 


### PR DESCRIPTION
`exif` seems to be pointing to a different cargo package that has not been updated in years.