### PR TITLE
Generate documentation for Tag consts

### DIFF
--- a/src/tag.rs
+++ b/src/tag.rs
@@ -175,6 +175,7 @@ macro_rules! generate_well_known_tag_constants {
         impl Tag {
             $($(
                 $( #[$attr] )*
+                #[doc = $desc]
                 #[allow(non_upper_case_globals)]
                 pub const $name: Tag = Tag($ctx, $num);
             )+)+


### PR DESCRIPTION
Uses the existing tag descriptions to add a line of documentation to each constant

---

I found myself looking through the source to find descriptions of each tag, so I figured I'd open this PR to put those in the documentation as well. Some of the doc comments are not *super* useful (e.g. `ImageWidth` -> "Image width"), but a lot of other ones are -- especially for someone who isn't super knowledgeable about Exif.