### PR TITLE
enum Values now derives PartialEq.

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -31,7 +31,7 @@ use crate::endian::Endian;
 use crate::error::Error;
 
 /// A type and values of a TIFF/Exif field.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum Value {
     /// Vector of 8-bit unsigned integers.
     Byte(Vec<u8>),
@@ -346,7 +346,7 @@ impl From<&DefaultValue> for Option<Value> {
 }
 
 /// An unsigned rational number, which is a pair of 32-bit unsigned integers.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct Rational { pub num: u32, pub denom: u32 }
 
 impl Rational {
@@ -384,7 +384,7 @@ impl fmt::Display for Rational {
 }
 
 /// A signed rational number, which is a pair of 32-bit signed integers.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub struct SRational { pub num: i32, pub denom: i32 }
 
 impl SRational {


### PR DESCRIPTION
I love this module... It is really useful.

but I am at the stage where I want Value to provide PartialEq,

[ To get this to compile both  Rational and SRational need to derive PartialEq. ]


```rustlang
/// A type and values of a TIFF/Exif field.
#[derive(Clone, PartialEq)]
pub enum Value {
    /// Vector of 8-bit unsigned integers.
    Byte(Vec<u8>),
    /// Vector of slices of 8-bit bytes containing 7-bit ASCII characters.
    /// The trailing null characters are not included.  Note that
    /// the 8th bits may present if a non-conforming data is given.
    Ascii(Vec<Vec<u8>>),
    /// Vector of 16-bit unsigned integers.
    Short(Vec<u16>),
    /// Vector of 32-bit unsigned integers.
    Long(Vec<u32>),

...


}
```