### PR TITLE
Increasing MAX_EXIF_SIZE for latest HEIF mirrorless camera

### DIFF
--- a/src/isobmff.rs
+++ b/src/isobmff.rs
@@ -36,7 +36,7 @@ use crate::util::{read64, BufReadExt as _, ReadExt as _};
 // Same for "msf1" [ISO23008-12 B.4.2] [ISO23008-12 B.4.4].
 static HEIF_BRANDS: &[[u8; 4]] = &[*b"mif1", *b"msf1"];
 
-const MAX_EXIF_SIZE: usize = 65535;
+const MAX_EXIF_SIZE: usize = 131070;
 
 // Most errors in this file are Error::InvalidFormat.
 impl From<&'static str> for Error {


### PR DESCRIPTION
- Panasonic Lumix S1R2 has 102400 bytes for EXIF on HEIF.
- Sony A7C2 has 94208 bytes for EXIF on HEIF.
- Consider those and HEIF from latest mirrorless camera, need to increase MAX_EXIF_SIZE

I will checking Canon's R5M2 to insure 131070 bytes is enough to use