### PR TITLE
feat: add exif parser to GeoJSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ license = "BSD-2-Clause"
 
 [dependencies]
 mutate_once = "0.1.1"
+
+[features]
+geojson = []

--- a/README
+++ b/README
@@ -12,6 +12,8 @@ Exif parsing library written in pure Rust
    -  PNG
    -  WebP
 
+   It can also convert Exif data to GeoJSON specification.
+
 Usage
 -----
 
@@ -20,7 +22,9 @@ Usage
    but it is renamed on crates.io to avoid a naming conflict.
 
       [dependencies]
-      kamadak-exif = "x.y.z"
+      kamadak-exif = { version="x.y.z",  features= ["geojson"] }
+   
+   If you want geojson features, 
 
    Add the following to your crate root (before Rust 2018).
 

--- a/src/geojson/converter.rs
+++ b/src/geojson/converter.rs
@@ -1,0 +1,121 @@
+use crate::{Exif, Field, In, Tag};
+
+#[derive(Debug)]
+pub enum ConverterError {
+    FailedToGetXYZ,
+    MissingField,
+    FailedToConvert,
+}
+
+/**
+ * Retrieve coordinates from exif
+ */
+pub fn parse_coords_from_exif_fields(
+    exif: &Exif,
+    get_latitude: bool,
+) -> Result<f64, ConverterError> {
+    let gps_ref = exif
+        .get_field(
+            if get_latitude {
+                Tag::GPSLatitudeRef
+            } else {
+                Tag::GPSLongitudeRef
+            },
+            In::PRIMARY,
+        )
+        .ok_or(ConverterError::MissingField)?;
+    let gps_field = exif
+        .get_field(
+            if get_latitude {
+                Tag::GPSLatitude
+            } else {
+                Tag::GPSLongitude
+            },
+            In::PRIMARY,
+        )
+        .ok_or(ConverterError::MissingField)?;
+    let dd = get_exif_xyz(gps_field)
+        .and_then(|xyz| convert_exif_dms_to_dd(&xyz, &gps_ref.display_value().to_string()))
+        .map_err(|_| ConverterError::FailedToConvert)?;
+    Ok(dd)
+}
+
+/**
+ * Retrieve X, Y and Z value from exif GPS Field
+ */
+pub fn get_exif_xyz(gps_field: &Field) -> Result<[f64; 3], ConverterError> {
+    let xyz = gps_field
+        .value
+        .rational()
+        .and_then(|value| value.get(..3))
+        .and_then(|xyz| Some([xyz[0].to_f64(), xyz[1].to_f64(), xyz[2].to_f64()]))
+        .ok_or(ConverterError::FailedToGetXYZ)?;
+    Ok(xyz)
+}
+
+/**
+ * Convert degrees minutes seconds to degrees decimals
+ */
+pub fn convert_exif_dms_to_dd(xyz: &[f64; 3], gps_ref: &str) -> Result<f64, ConverterError> {
+    let [degrees, minutes, seconds] = xyz;
+    let mut dd: f64 = degrees + (minutes / 60.0) + (seconds / 3600.0);
+    // Update sign
+    if ["S", "W"].contains(&gps_ref.to_uppercase().as_str()) {
+        dd *= -1.0;
+    }
+    Ok(dd)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io::BufReader};
+
+    use crate::{
+        geojson::converter::{convert_exif_dms_to_dd, get_exif_xyz, parse_coords_from_exif_fields},
+        In, Reader, Tag,
+    };
+
+    #[test]
+    fn test_convert_dms_north() {
+        let result = convert_exif_dms_to_dd(&[45., 30., 10.], "N").unwrap();
+        assert_eq!(result, 45.50277777777778);
+    }
+
+    #[test]
+    fn test_convert_dms_south() {
+        let result = convert_exif_dms_to_dd(&[45., 30., 10.], "S").unwrap();
+        assert_eq!(result, -45.50277777777778);
+    }
+
+    #[test]
+    fn test_convert_dms_east() {
+        let result = convert_exif_dms_to_dd(&[45., 30., 10.], "E").unwrap();
+        assert_eq!(result, 45.50277777777778);
+    }
+
+    #[test]
+    fn test_convert_dms_west() {
+        let result = convert_exif_dms_to_dd(&[45., 30., 10.], "W").unwrap();
+        assert_eq!(result, -45.50277777777778);
+    }
+
+    #[test]
+    fn test_get_xyz() {
+        let file = File::open("tests/yaminabe.tif").unwrap();
+        let exif = Reader::new()
+            .read_from_container(&mut BufReader::new(&file))
+            .unwrap();
+        let latitude_field = exif.get_field(Tag::GPSLatitude, In::PRIMARY).unwrap();
+        let result = get_exif_xyz(latitude_field).unwrap();
+        assert_eq!(result, [10., 0., 0.]);
+    }
+
+    #[test]
+    fn test_parse_coords() {
+        let file = File::open("tests/yaminabe.tif").unwrap();
+        let exif = Reader::new()
+            .read_from_container(&mut BufReader::new(&file))
+            .unwrap();
+        assert!(parse_coords_from_exif_fields(&exif, true).is_err())
+    }
+}

--- a/src/geojson/geojson.rs
+++ b/src/geojson/geojson.rs
@@ -1,0 +1,210 @@
+use std::{collections::HashMap, fmt, vec};
+
+use crate::{geojson::converter::parse_coords_from_exif_fields, Exif};
+
+#[derive(Debug, Clone)]
+enum CoordinatesError {
+    InvalidLongitude(f64),
+    InvalidLatitude(f64),
+}
+
+#[derive(Debug, Clone)]
+struct PointGeometry {
+    r#type: &'static str,
+    coordinates: [f64; 2],
+}
+
+impl TryFrom<[f64; 2]> for PointGeometry {
+    type Error = CoordinatesError;
+    fn try_from(coordinates: [f64; 2]) -> Result<Self, Self::Error> {
+        let [lon, lat] = coordinates;
+
+        if !(-180.0..=180.0).contains(&lon) {
+            return Err(CoordinatesError::InvalidLongitude(lon));
+        }
+
+        if !(-90.0..=90.0).contains(&lat) {
+            return Err(CoordinatesError::InvalidLatitude(lat));
+        }
+        Ok(Self {
+            r#type: "Point",
+            coordinates: [lon, lat],
+        })
+    }
+}
+
+impl fmt::Display for PointGeometry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{{\"type\":\"{}\",\"coordinates\":[{},{}]}}",
+            self.r#type, self.coordinates[0], self.coordinates[1]
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct GeoJSON {
+    r#type: &'static str,
+    geometry: PointGeometry,
+    properties: HashMap<String, String>,
+}
+
+impl GeoJSON {
+    pub fn new(geometry: PointGeometry, properties: HashMap<String, String>) -> Self {
+        Self {
+            r#type: "Feature",
+            geometry: geometry,
+            properties: properties,
+        }
+    }
+}
+
+impl fmt::Display for GeoJSON {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut properties = String::from("{");
+        for (index, (key, value)) in self.properties.iter().enumerate() {
+            if index > 0 {
+                properties.push(',');
+            }
+            properties.push_str(format!("\"{}\":\"{}\"", key, value).as_str())
+        }
+        properties.push('}');
+        write!(
+            f,
+            "{{\"type\":\"{}\",\"geometry\":{},\"properties\":{}}}",
+            self.r#type,
+            self.geometry.to_string(),
+            properties
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ExifCoordinatesError {
+    FailedToCreatePoint,
+    FailedToGetLatitude,
+    FailedToGetLongitude,
+}
+/// A struct used to parse exif metadata to GeoJSONCollection.
+/// # Example
+/// ```
+///  use exif::{In, Reader, Tag, Value, GeoJSONCollection};
+///  let file = std::fs::File::open("tests/exif.tif").unwrap();
+///  let exif = Reader::new().read_from_container(
+///      &mut std::io::BufReader::new(&file)).unwrap();
+///  let geojson = GeoJSONCollection::try_from(&exif).unwrap();
+///  let geojson_stringified = geojson.to_string();
+///
+/// ```
+#[derive(Debug, Clone)]
+pub struct GeoJSONCollection {
+    r#type: &'static str,
+    features: Vec<GeoJSON>,
+}
+
+impl TryFrom<&Exif> for GeoJSONCollection {
+    type Error = ExifCoordinatesError;
+
+    fn try_from(value: &Exif) -> Result<Self, Self::Error> {
+        let latitude = parse_coords_from_exif_fields(&value, true)
+            .map_err(|_| ExifCoordinatesError::FailedToGetLatitude)?;
+
+        let longitude = parse_coords_from_exif_fields(&value, false)
+            .map_err(|_| ExifCoordinatesError::FailedToGetLongitude)?;
+
+        let point = PointGeometry::try_from([longitude, latitude])
+            .map_err(|_| ExifCoordinatesError::FailedToCreatePoint)?;
+        let mut properties: HashMap<String, String> = HashMap::new();
+        for f in value.fields() {
+            properties.insert(f.tag.to_string(), f.display_value().to_string());
+        }
+        let feature = GeoJSON::new(point, properties);
+        Ok(Self {
+            r#type: "FeatureCollection",
+            features: vec![feature],
+        })
+    }
+}
+
+impl fmt::Display for GeoJSONCollection {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut features = String::from("[");
+        for feat in &self.features {
+            features.push_str(feat.to_string().as_str());
+        }
+        features.push(']');
+        write!(
+            f,
+            "{{\"type\":\"{}\",\"features\":{}}}",
+            self.r#type, features,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, fs::File, io::BufReader};
+
+    use crate::{
+        geojson::geojson::{GeoJSON, GeoJSONCollection, PointGeometry},
+        Reader,
+    };
+
+    #[test]
+    fn point_geometry_with_good_coordinates() {
+        let coordinates = [2., 79.];
+        let pt = PointGeometry::try_from(coordinates);
+        assert!(pt.is_ok());
+    }
+
+    #[test]
+    fn point_geometry_with_wrong_coordinates() {
+        let coordinates = [200., 79.];
+        let pt = PointGeometry::try_from(coordinates);
+        assert!(pt.is_err());
+    }
+
+    #[test]
+    fn point_geometry_to_string() {
+        let coordinates = [2., 79.];
+        let pt = PointGeometry::try_from(coordinates).unwrap();
+        assert_eq!(
+            pt.to_string(),
+            "{\"type\":\"Point\",\"coordinates\":[2,79]}"
+        );
+    }
+
+    #[test]
+    fn geojson_empty() {
+        let geojson = GeoJSON::new(PointGeometry::try_from([0., 0.]).unwrap(), HashMap::new());
+        assert_eq!(geojson.geometry.coordinates.len(), 2);
+        assert_eq!(geojson.geometry.coordinates.get(0), Some(&0.));
+        assert_eq!(geojson.properties.len(), 0);
+        assert_eq!(geojson.r#type, "Feature".to_owned());
+    }
+
+    #[test]
+    fn geojson() {
+        let mut properties = HashMap::<String, String>::new();
+        properties.insert("GPSLatitude".to_owned(), "39 deg 3 min 4.84 sec".to_owned());
+        properties.insert("Acceleration".to_owned(), "100".to_owned());
+        let geojson_struct = GeoJSON::new(PointGeometry::try_from([179., 0.]).unwrap(), properties);
+        assert_eq!(geojson_struct.geometry.coordinates.len(), 2);
+        assert_eq!(geojson_struct.geometry.coordinates.get(0), Some(&179.));
+        assert_eq!(geojson_struct.properties.len(), 2);
+        assert_eq!(
+            geojson_struct.to_string(),
+            "{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[179,0]},\"properties\":{\"GPSLatitude\":\"39 deg 3 min 4.84 sec\",\"Acceleration\":\"100\"}}"
+        );
+    }
+
+    #[test]
+    fn geojson_collection() {
+        let file = File::open("tests/yaminabe.tif").unwrap();
+        let exif = Reader::new()
+            .read_from_container(&mut BufReader::new(&file))
+            .unwrap();
+        assert!(GeoJSONCollection::try_from(&exif).is_err());
+    }
+}

--- a/src/geojson/mod.rs
+++ b/src/geojson/mod.rs
@@ -1,0 +1,2 @@
+mod converter;
+pub mod geojson;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,11 +91,14 @@
 
 pub use error::{Error, PartialResult};
 pub use exifimpl::Exif;
+#[cfg(feature = "geojson")]
+pub use geojson::geojson::*;
+
 pub use jpeg::get_exif_attr as get_exif_attr_from_jpeg;
 pub use reader::Reader;
 pub use tag::{Context, Tag};
-pub use tiff::{DateTime, Field, In};
 pub use tiff::parse_exif;
+pub use tiff::{DateTime, Field, In};
 pub use value::Value;
 pub use value::{Rational, SRational};
 
@@ -112,6 +115,7 @@ pub mod doc;
 mod endian;
 mod error;
 mod exifimpl;
+mod geojson;
 mod isobmff;
 mod jpeg;
 mod png;


### PR DESCRIPTION
### Summary

This PR adds EXIF metadata parsing support to GeoJSON specification.

Images containing GPS EXIF metadata can now be converted into valid GeoJSON point geometries automatically.

### Changes

- Extract GPS coordinates from image metadata
- Convert extracted coordinates into GeoJSON Point geometry
- Added coordinate validation
- Added tests for EXIF parsing and GeoJSON conversion

### Motivation

This feature simplifies the process of generating GeoJSON data directly from geotagged images and improves interoperability with mapping/GIS tools.